### PR TITLE
Feat/improve UUID varchar dataypes

### DIFF
--- a/datafiller
+++ b/datafiller
@@ -2389,7 +2389,7 @@ RE_SER=r'(SMALL|BIG)?SERIAL|SERIAL[248]'
 RE_BLO=r'BYTEA|BLOB'
 RE_INT=r'{0}|(TINY|SMALL|MEDIUM)INT|INT[248]|INTEGER|INT\b'.format(RE_SER)
 RE_FLT=r'REAL|FLOAT|DOUBLE\s+PRECISION|NUMERIC|DECIMAL'
-RE_TXT=r'TEXT|CHAR\(\d+\)|VARCHAR\(\d+\)'
+RE_TXT=r'TEXT|CHAR\(\d+\)|VARCHAR(\(\d+\))?'
 RE_BIT=r'BIT\(\d+\)|VARBIT\(\d+\)'
 RE_TSTZ=r'TIMESTAMP(\s+WITH\s+TIME\s+ZONE)?'
 RE_INTV=r'INTERVAL'
@@ -4370,8 +4370,7 @@ class Database(object):
         t = type.lower()
         return t == 'smallint' or t == 'int' or t == 'integer' or t == 'bigint'
     def textType(self, type):
-        t = type.lower()
-        return t == 'text' or re.match(r'(var)?char\(', t)
+        return re.match(RE_TXT + '$', type, re.I)
     def boolType(self, type):
         t = type.lower()
         return t == 'bool' or t == 'boolean'

--- a/datafiller
+++ b/datafiller
@@ -3979,8 +3979,8 @@ class BitGenerator(WithLength, RandomGenerator):
 def UUIDGenerator(att, params=None):
     if not params:
         params = att.params
-    params['pattern'] = r'\h{4}(\h{4}-){4}\h{12}'
-    return PatternGenerator(att, params)
+    params['format'] = '032X'
+    return CountGenerator(att, params)
 
 # all user-visible generators
 GENERATORS = {


### PR DESCRIPTION
This PR fixes two issues I've found:

1. VARCHAR types can be written without length parameter, essentially they can be an alias to TEXT.
2. make UUID types use a count generator with 32 hexadecimal characters. That way they can have an unique index which using a pattern (chars generators) didn't allow.

Example table with both errors:

```sql
create table app_public.projects (
  id                  uuid primary key default gen_random_uuid(),
  name                varchar not null
)
```